### PR TITLE
Fix errors with downloading from Kemono backup

### DIFF
--- a/src/api/cookie.go
+++ b/src/api/cookie.go
@@ -55,6 +55,9 @@ func getHeaders(website, userAgent string) map[string]string {
 	case utils.KEMONO :
 		referer = utils.KEMONO_URL
 		origin = utils.KEMONO_URL
+	case utils.KEMONO_BACKUP :
+		referer = utils.BACKUP_KEMONO_URL
+		origin = utils.BACKUP_KEMONO_URL
 	default :
 		// Shouldn't happen but could happen during development
 		panic(

--- a/src/utils/constants.go
+++ b/src/utils/constants.go
@@ -83,9 +83,9 @@ const (
 	KEMONO_TLD                  = "party"
 	KEMONO_BACKUP_TLD           = "su"
 	KEMONO_URL                  = "https://kemono.party"
-	KEMONO_API_URL              = "https://kemono.party/api"
+	KEMONO_API_URL              = "https://kemono.party/api/v1"
 	BACKUP_KEMONO_URL           = "https://kemono.su"
-	BACKUP_KEMONO_API_URL       = "https://kemono.su/api"
+	BACKUP_KEMONO_API_URL       = "https://kemono.su/api/v1"
 
 	PASSWORD_FILENAME = "detected_passwords.txt"
 	ATTACHMENT_FOLDER = "attachments"


### PR DESCRIPTION
# Addition to code

## Type of additions (Tick those that apply):

<!-- Use ✗/✓ for the following type of additions -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Program Version

Version: latest commit as of 2024-02-01 [016438d](https://github.com/KJHJason/Cultured-Downloader-CLI/commit/016438dcd461ccdf07824d1bb4baeb99ce94db4f) <!-- 1.0.0 or based on my latest commit [fe1a33a](https://github.com/KJHJason/Cultured-Downloader-CLI/commit/fe1a33a2da3ea5e1338da912bea1899247648b81) -->

## Summary of changes:

Fixes two issues with downloading from Kemono.su:
 - Missing switch-case for the backup site, and
 - Incorrect API url missing `/v1`. See https://kemono.su/api/schema 

## Checklist (Tick those that apply):

<!-- Use ✗/✓ for the following checklist -->

- [x] I have read the [contribution guidelines](https://github.com/KJHJason/Cultured-Downloader-CLI/blob/main/CONTRIBUTING.md) and have adhered to it
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any spelling mistakes

### Verification
- [x] Downloading single post works:
```
go run . kemono --post_url https://kemono.party/patreon/user/97081801/post/96841391 -g false -l -s <session cookie>
```

## Screenshots (if any):

<!-- This is used for comparing any changes via screenshots -->
| Original            | Updated            |
| ------------------- |:------------------:|
| original screenshot | updated screenshot |