### PR TITLE
Fix unmarshalling error on downloading individual posts

### DIFF
--- a/src/api/kemono/api.go
+++ b/src/api/kemono/api.go
@@ -167,12 +167,13 @@ func getPostDetails(post *models.KemonoPostToDl, downloadPath string, dlOptions 
 		return nil, nil, err
 	}
 
-	var resJson models.KemonoJson
+	// Single post cannot unmarshal into a slice
+	var resJson models.MainKemonoJson
 	if err := utils.LoadJsonFromResponse(res, &resJson); err != nil {
 		return nil, nil, err
 	}
 
-	postsToDl, gdriveLinks := processMultipleJson(resJson, post.Tld, downloadPath, dlOptions)
+	postsToDl, gdriveLinks := processMultipleJson([]*models.MainKemonoJson{&resJson}, post.Tld, downloadPath, dlOptions)
 	return postsToDl, gdriveLinks, nil
 }
 


### PR DESCRIPTION
# Addition to code

## Type of additions (Tick those that apply):

<!-- Use ✗/✓ for the following type of additions -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Program Version

Version: <!-- 1.0.0 or based on my latest commit [fe1a33a](https://github.com/KJHJason/Cultured-Downloader-CLI/commit/fe1a33a2da3ea5e1338da912bea1899247648b81) -->

## Summary of changes:

Fixes an umarshaling issue with downloading individual posts from Kemono; the JSON response contains only a single object, and cannot be unmarshaled into a slice. 

## Checklist (Tick those that apply):

<!-- Use ✗/✓ for the following checklist -->

- [x] I have read the [contribution guidelines](https://github.com/KJHJason/Cultured-Downloader-CLI/blob/main/CONTRIBUTING.md) and have adhered to it
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any spelling mistakes

### Verification
- [x] Downloading a single post works
```
go run . kemono --post_url https://kemono.party/patreon/user/97081801/post/96841391 -g false -l -s <cookie session>
```

## Screenshots (if any):

<!-- This is used for comparing any changes via screenshots -->
| Original            | Updated            |
| ------------------- |:------------------:|
| original screenshot | updated screenshot |